### PR TITLE
Additional BLAST Applications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,139 @@
+  
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/blastApp.py
+++ b/blastApp.py
@@ -4,62 +4,85 @@ try:
     from sys	 	import exc_info, argv
     from bs4		import BeautifulSoup as BSoup
     from requests 	import post, get
+    import re
 except ImportError:
     print("[!] Error: One or more library(ies) wasn't found!")
     exit(-1)
 
-if len(argv) != 2:
-    print("[~] Usage:\n{0} <Amino Acids Sequence>\n".format(argv[0]))
-    exit(0)
-
 # Defining the Restful API URI and connection parameters
 blastURI = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi"
 headers  = {"Content-Type":"application/x-www-form-urlencoded"}
-# protDBs  = ['nr', 'refseq_select', 'refseq_protein', 'landmark', 'swissprot', 'pataa', 'pdb', 'env_nr', 'tsa_nr']
-data     = "CMD=Put&PROGRAM=blastx&DATABASE=swissprot&QUERY={0}".format(argv[1])
 
-try:
-    req = post(blastURI, headers=headers, data=data)
-except (Exception) as exc:
-    exc_type, exc_obj, exc_tb = exc_info()
-    print("[!]\nException: {0}\nMessage: {1}\nLine Number: {2}".format( \
-         type(exc), exc, exc_tb.tb_lineno))
-    exit(-1)
+# Dictionary with the available databases for each Blast application, along with regex expressions to validate the nucleotide/aa sequence
+parser = {
+    'blastn':{'regex':r'[^A|C|G|T]', 'db':['nt','refseq_select','refseq_genomes','wgs','est','env_nt','tsa_nt','patnt','pdbnt','refseqgene','vector','gss','dbsts']},
+    'blastp':{'regex':r'[J|O|U|X|\W]', 'db':['nr', 'refseq_select', 'refseq_protein', 'landmark', 'swissprot', 'pataa', 'pdb', 'env_nr', 'tsa_nr']},
+    'blastx':{'regex':r'[^A|C|G|T]', 'db':['nr', 'refseq_select', 'refseq_protein', 'landmark', 'swissprot', 'pataa', 'pdb', 'env_nr', 'tsa_nr']}
+}
 
-if req.status_code != 200:
-    print("[!] [{0}]\n{1}".format(req.status_code, req.text))
-    exit(0)
+def runQuery(application, db, sequence):
+    data = "CMD=Put&PROGRAM={application}&DATABASE={db}&QUERY={sequence}".format(application=application, db=db, sequence=sequence)
 
-# Get request ID for results polling later
-try:
-    blastReqID = BSoup(req.text, 'lxml').findAll('input', {'type':'text'})[0]['value']
-except:
-    print("[!] Couldn't find the request ID value!\n")
-    exit(0)
+    try:
+        req = post(blastURI, headers=headers, data=data)
+    except (Exception) as exc:
+        exc_type, exc_obj, exc_tb = exc_info()
+        print("[!]\nException: {0}\nMessage: {1}\nLine Number: {2}".format( \
+            type(exc), exc, exc_tb.tb_lineno))
+        exit(-1)
 
-# Poll for results
-blastPollURI = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi?CMD=Get"+ \
-               "&FORMAT_OBJECT=SearchInfo&RID={0}".format(blastReqID)
-while True:
-    sleep(5)
-    req = get(blastPollURI)
-    if req.text.find('Status=READY') != -1:
-        break
+    if req.status_code != 200:
+        print("[!] [{0}]\n{1}".format(req.status_code, req.text))
+        exit(0)
 
-if req.text.find('ThereAreHits=yes') == -1:
-    print("[!] No results returned from Blast DB!")
-    exit(0)
+    # Get request ID for results polling later
+    try:
+        blastReqID = BSoup(req.text, 'lxml').findAll('input', {'type':'text'})[0]['value']
+    except:
+        print("[!] Couldn't find the request ID value!\n")
+        exit(0)
 
-# Retrieve results
-blastResURI = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi?CMD=Get"+ \
-              "&FORMAT_TYPE=Text&RID={0}".format(blastReqID)
+    # Poll for results
+    blastPollURI = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi?CMD=Get"+ \
+                "&FORMAT_OBJECT=SearchInfo&RID={0}".format(blastReqID)
+    while True:
+        sleep(5)
+        req = get(blastPollURI)
+        if req.text.find('Status=READY') != -1:
+            break
 
-# Write results to file
-req = get(blastResURI)
-with open('./results.txt', 'w+') as f:
-    f.write(req.text)
+    if req.text.find('ThereAreHits=yes') == -1:
+        print("[!] No results returned from Blast DB!")
+        exit(0)
 
-print("[~] Results stored in file 'results.txt'")
+    # Retrieve results
+    blastResURI = "https://blast.ncbi.nlm.nih.gov/blast/Blast.cgi?CMD=Get"+ \
+                "&FORMAT_TYPE=Text&RID={0}".format(blastReqID)
 
+    # Write results to file
+    req = get(blastResURI)
+    with open('./results.txt', 'w+') as f:
+        f.write(req.text)
 
+    print("[~] Results stored in file 'results.txt'")
 
+if __name__ == '__main__':
+    if len(argv) != 4:
+        print("[~] Usage:\n{0} <Amino Acids or Nucleotide Sequence> <Database> <Blast Application>\n".format(argv[0]))
+        exit(0)
+    seq = argv[1]
+    db = argv[2]
+    application = argv[3]
+    
+    # Argument validation
+    if application not in parser.keys():
+        print('[!] Invalid program')
+        exit(0)
+    if db not in parser[application]['db']:
+        print('[!] Invalid database')
+        exit(0)
+    if re.findall(parser[application]['regex'], seq):
+        print('[!] Invalid sequence for the selected application')
+        exit(0)
+
+    runQuery(application, db, seq)


### PR DESCRIPTION
## Proposed Changes to Enable Additional BLAST Applications (blastn and blastp)

  - Added a dictionary with the available databases for each BLAST application (only blastn, blastp, and blastx currently), along with regex expressions to validate the provided nucleotide or amino acid sequence. That is used to confirm the arguments are valid and if not, raise an error to the user. 
  - Converted the core part of the script into a main function to execute the API calls and the output of the results. Although not strictly necessary at this point, it might prove useful if the script is expanded to cover additional functionalities of the BLAST API.
  - Added an entry point to the script that validates the arguments (sequence, database, and BLAST application) and executes the main function.
